### PR TITLE
SOR-1876 add graphite metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -58,6 +58,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:7b274cc72af687fe6eb618acd83b9601c4317fbe5ac1dfb41cc116e3495f68b0"
+  name = "github.com/cyberdelia/go-metrics-graphite"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "39f87cc3b432bbb898d7c643c0e93cac2bc865ad"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -123,18 +131,6 @@
   pruneopts = "UT"
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:4f269c76ac3a3ac14014412f3ae2149cca9a606183c86012d6ed864e78801009"
-  name = "github.com/influxdata/influxdb"
-  packages = [
-    "client",
-    "models",
-    "pkg/escape",
-  ]
-  pruneopts = "UT"
-  revision = "5766854b95ae86cccf6cc8ffe4c5bb9eacc994b8"
-  version = "v1.6.1"
 
 [[projects]]
   digest = "1:ccfa094742ce1c97fd3f6481e1bf98f3d9862510eee2bc0eb56e2745396bd330"
@@ -350,14 +346,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6764eb3d860b8bbcec6713633c372a44d31fbc73ab740d1f95682782373d8293"
-  name = "github.com/vrischmann/go-metrics-influxdb"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "43af8332c303f62ef62663b02b3b7d8a9802002a"
-
-[[projects]]
-  branch = "master"
   digest = "1:f4e5276a3b356f4692107047fd2890f2fe534f4feeb6b1fd2f6dfbd87f1ccf54"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
@@ -463,6 +451,7 @@
     "github.com/buger/jsonparser",
     "github.com/chasex/glog",
     "github.com/coocood/freecache",
+    "github.com/cyberdelia/go-metrics-graphite",
     "github.com/erikstmartin/go-testdb",
     "github.com/evanphx/json-patch",
     "github.com/golang/glog",
@@ -483,7 +472,6 @@
     "github.com/rs/cors",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
-    "github.com/vrischmann/go-metrics-influxdb",
     "github.com/xeipuuv/gojsonschema",
     "github.com/yudai/gojsondiff",
     "github.com/yudai/gojsondiff/formatter",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,6 +133,18 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4f269c76ac3a3ac14014412f3ae2149cca9a606183c86012d6ed864e78801009"
+  name = "github.com/influxdata/influxdb"
+  packages = [
+    "client",
+    "models",
+    "pkg/escape",
+  ]
+  pruneopts = "UT"
+  revision = "5766854b95ae86cccf6cc8ffe4c5bb9eacc994b8"
+  version = "v1.6.1"
+
+[[projects]]
   digest = "1:ccfa094742ce1c97fd3f6481e1bf98f3d9862510eee2bc0eb56e2745396bd330"
   name = "github.com/julienschmidt/httprouter"
   packages = ["."]
@@ -346,6 +358,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:6764eb3d860b8bbcec6713633c372a44d31fbc73ab740d1f95682782373d8293"
+  name = "github.com/vrischmann/go-metrics-influxdb"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "43af8332c303f62ef62663b02b3b7d8a9802002a"
+
+[[projects]]
+  branch = "master"
   digest = "1:f4e5276a3b356f4692107047fd2890f2fe534f4feeb6b1fd2f6dfbd87f1ccf54"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
@@ -472,6 +492,7 @@
     "github.com/rs/cors",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
+    "github.com/vrischmann/go-metrics-influxdb",
     "github.com/xeipuuv/gojsonschema",
     "github.com/yudai/gojsondiff",
     "github.com/yudai/gojsondiff/formatter",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,7 +75,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/vrischmann/go-metrics-influxdb"
+  name = "github.com/cyberdelia/go-metrics-graphite"
 
 [[constraint]]
   name = "github.com/yudai/gojsondiff"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,6 +75,10 @@
 
 [[constraint]]
   branch = "master"
+  name = "github.com/vrischmann/go-metrics-influxdb"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/cyberdelia/go-metrics-graphite"
 
 [[constraint]]

--- a/config/config.go
+++ b/config/config.go
@@ -165,12 +165,21 @@ type Adapter struct {
 }
 
 type Metrics struct {
+	Influxdb   InfluxMetrics     `mapstructure:"influxdb"`
 	Graphite   GraphiteMetrics   `mapstructure:"graphite"`
 	Prometheus PrometheusMetrics `mapstructure:"prometheus"`
 }
 
+type InfluxMetrics struct {
+	Host     string `mapstructure:"host"`
+	Database string `mapstructure:"database"`
+	Username string `mapstructure:"username"`
+	Password string `mapstructure:"password"`
+}
+
 type GraphiteMetrics struct {
 	Host        string `mapstructure:"host"`
+	Prefix      string `mapstructure:"prefix"`
 	IntervalSec uint   `mapstructure:"interval_sec"`
 }
 
@@ -299,7 +308,12 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("http_client.max_idle_connections_per_host", 10)
 	v.SetDefault("http_client.idle_connection_timeout_seconds", 60)
 	// no metrics configured by default (metrics{host|database|username|password})
+	v.SetDefault("metrics.influxdb.host", "")
+	v.SetDefault("metrics.influxdb.database", "")
+	v.SetDefault("metrics.influxdb.username", "")
+	v.SetDefault("metrics.influxdb.password", "")
 	v.SetDefault("metrics.graphite.host", "")
+	v.SetDefault("metrics.graphite.prefix", "")
 	v.SetDefault("metrics.graphite.interval_sec", 10)
 	v.SetDefault("metrics.prometheus.endpoint", "")
 	v.SetDefault("metrics.prometheus.port", 0)

--- a/config/config.go
+++ b/config/config.go
@@ -165,15 +165,13 @@ type Adapter struct {
 }
 
 type Metrics struct {
-	Influxdb   InfluxMetrics     `mapstructure:"influxdb"`
+	Graphite   GraphiteMetrics   `mapstructure:"graphite"`
 	Prometheus PrometheusMetrics `mapstructure:"prometheus"`
 }
 
-type InfluxMetrics struct {
-	Host     string `mapstructure:"host"`
-	Database string `mapstructure:"database"`
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
+type GraphiteMetrics struct {
+	Host        string `mapstructure:"host"`
+	IntervalSec uint   `mapstructure:"interval_sec"`
 }
 
 type PrometheusMetrics struct {
@@ -301,10 +299,8 @@ func SetupViper(v *viper.Viper, filename string) {
 	v.SetDefault("http_client.max_idle_connections_per_host", 10)
 	v.SetDefault("http_client.idle_connection_timeout_seconds", 60)
 	// no metrics configured by default (metrics{host|database|username|password})
-	v.SetDefault("metrics.influxdb.host", "")
-	v.SetDefault("metrics.influxdb.database", "")
-	v.SetDefault("metrics.influxdb.username", "")
-	v.SetDefault("metrics.influxdb.password", "")
+	v.SetDefault("metrics.graphite.host", "")
+	v.SetDefault("metrics.graphite.interval_sec", 10)
 	v.SetDefault("metrics.prometheus.endpoint", "")
 	v.SetDefault("metrics.prometheus.port", 0)
 	v.SetDefault("metrics.prometheus.namespace", "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,11 +55,9 @@ http_client:
   idle_connection_timeout_seconds: 30
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
-  influxdb:
-    host: upstream:8232
-    database: metricsdb
-    username: admin
-    password: admin1324
+  graphite:
+    host: graphite_host:2003
+    interval_sec: 3
 datacache:
   type: postgres
   filename: /usr/db/db.db
@@ -137,10 +135,8 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "gdpr.host_vendor_id", cfg.GDPR.HostVendorID, 15)
 	cmpBools(t, "gdpr.usersync_if_ambiguous", cfg.GDPR.UsersyncIfAmbiguous, true)
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
-	cmpStrings(t, "metrics.influxdb.host", cfg.Metrics.Influxdb.Host, "upstream:8232")
-	cmpStrings(t, "metrics.influxdb.database", cfg.Metrics.Influxdb.Database, "metricsdb")
-	cmpStrings(t, "metrics.influxdb.username", cfg.Metrics.Influxdb.Username, "admin")
-	cmpStrings(t, "metrics.influxdb.password", cfg.Metrics.Influxdb.Password, "admin1324")
+	cmpStrings(t, "graphite.host", cfg.Metrics.Graphite.Host, "graphite_host:2003")
+	cmpInts(t, "graphite.interval_sec", int(cfg.Metrics.Graphite.IntervalSec), 3)
 	cmpStrings(t, "datacache.type", cfg.DataCache.Type, "postgres")
 	cmpStrings(t, "datacache.filename", cfg.DataCache.Filename, "/usr/db/db.db")
 	cmpInts(t, "datacache.cache_size", cfg.DataCache.CacheSize, 10000000)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,8 +55,14 @@ http_client:
   idle_connection_timeout_seconds: 30
 recaptcha_secret: asdfasdfasdfasdf
 metrics:
+  influxdb:
+    host: upstream:8232
+    database: metricsdb
+    username: admin
+    password: admin1324
   graphite:
     host: graphite_host:2003
+    prefix: test_prefix
     interval_sec: 3
 datacache:
   type: postgres
@@ -135,8 +141,13 @@ func TestFullConfig(t *testing.T) {
 	cmpInts(t, "gdpr.host_vendor_id", cfg.GDPR.HostVendorID, 15)
 	cmpBools(t, "gdpr.usersync_if_ambiguous", cfg.GDPR.UsersyncIfAmbiguous, true)
 	cmpStrings(t, "recaptcha_secret", cfg.RecaptchaSecret, "asdfasdfasdfasdf")
-	cmpStrings(t, "graphite.host", cfg.Metrics.Graphite.Host, "graphite_host:2003")
-	cmpInts(t, "graphite.interval_sec", int(cfg.Metrics.Graphite.IntervalSec), 3)
+	cmpStrings(t, "metrics.influxdb.host", cfg.Metrics.Influxdb.Host, "upstream:8232")
+	cmpStrings(t, "metrics.influxdb.database", cfg.Metrics.Influxdb.Database, "metricsdb")
+	cmpStrings(t, "metrics.influxdb.username", cfg.Metrics.Influxdb.Username, "admin")
+	cmpStrings(t, "metrics.influxdb.password", cfg.Metrics.Influxdb.Password, "admin1324")
+	cmpStrings(t, "metrics.graphite.host", cfg.Metrics.Graphite.Host, "graphite_host:2003")
+	cmpStrings(t, "metrics.graphite.prefix", cfg.Metrics.Graphite.Prefix, "test_prefix")
+	cmpInts(t, "metrics.graphite.interval_sec", int(cfg.Metrics.Graphite.IntervalSec), 3)
 	cmpStrings(t, "datacache.type", cfg.DataCache.Type, "postgres")
 	cmpStrings(t, "datacache.filename", cfg.DataCache.Filename, "/usr/db/db.db")
 	cmpInts(t, "datacache.cache_size", cfg.DataCache.CacheSize, 10000000)

--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -31,7 +31,7 @@ func NewMetricsEngine(cfg *config.Configuration, adapterList []openrtb_ext.Bidde
 		go graphite.Graphite(
 			returnEngine.GoMetrics.MetricsRegistry,
 			time.Duration(cfg.Metrics.Graphite.IntervalSec)*time.Second,
-			"servers."+hostname+".prebid-server",
+			"servers.com.sortable.ec2."+hostname+".prebid-server",
 			addr,
 		)
 		// Graphite is not added to the engine list as goMetrics takes care of it already.

--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -2,15 +2,16 @@ package config
 
 import (
 	"net"
-	"os"
 	"time"
 
 	"github.com/cyberdelia/go-metrics-graphite"
+	"github.com/golang/glog"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/pbsmetrics/prometheus"
 	"github.com/rcrowley/go-metrics"
+	"github.com/vrischmann/go-metrics-influxdb"
 )
 
 // NewMetricsEngine reads the configuration and returns the appropriate metrics engine
@@ -22,19 +23,35 @@ func NewMetricsEngine(cfg *config.Configuration, adapterList []openrtb_ext.Bidde
 	engineList := make(MultiMetricsEngine, 0, 2)
 	returnEngine := DetailedMetricsEngine{}
 
-	if cfg.Metrics.Graphite.Host != "" {
-		returnEngine.GoMetrics = pbsmetrics.NewMetrics(metrics.NewRegistry(), adapterList)
+	if cfg.Metrics.Influxdb.Host != "" || cfg.Metrics.Graphite.Host != "" {
+		// Currently use go-metrics as the metrics piece for influx
+		returnEngine.GoMetrics = pbsmetrics.NewMetrics(metrics.NewPrefixedRegistry("prebidserver."), adapterList)
 		engineList = append(engineList, returnEngine.GoMetrics)
-		// Set up the Graphite logger
-		addr, _ := net.ResolveTCPAddr("tcp", cfg.Metrics.Graphite.Host)
-		hostname, _ := os.Hostname()
-		go graphite.Graphite(
-			returnEngine.GoMetrics.MetricsRegistry,
-			time.Duration(cfg.Metrics.Graphite.IntervalSec)*time.Second,
-			"servers.com.sortable.ec2."+hostname+".prebid-server",
-			addr,
-		)
-		// Graphite is not added to the engine list as goMetrics takes care of it already.
+		if cfg.Metrics.Influxdb.Host != "" {
+			// Set up the Influx logger
+			go influxdb.InfluxDB(
+				returnEngine.GoMetrics.MetricsRegistry, // metrics registry
+				time.Second*10,                         // interval
+				cfg.Metrics.Influxdb.Host,              // the InfluxDB url
+				cfg.Metrics.Influxdb.Database,          // your InfluxDB database
+				cfg.Metrics.Influxdb.Username,          // your InfluxDB user
+				cfg.Metrics.Influxdb.Password,          // your InfluxDB password
+			)
+		}
+		if cfg.Metrics.Graphite.Host != "" {
+			addr, err := net.ResolveTCPAddr("tcp", cfg.Metrics.Graphite.Host)
+			if err == nil {
+				go graphite.Graphite(
+					returnEngine.GoMetrics.MetricsRegistry,
+					time.Duration(cfg.Metrics.Graphite.IntervalSec)*time.Second,
+					cfg.Metrics.Graphite.Prefix,
+					addr,
+				)
+			} else {
+				glog.Errorf("Cannot resolve graphite host %s: %v", cfg.Metrics.Graphite.Host, err)
+			}
+		}
+		// Influx and graphite is not added to the engine list as goMetrics takes care of it already.
 	}
 	if cfg.Metrics.Prometheus.Port != 0 {
 		// Set up the Prometheus metrics.

--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -1,14 +1,16 @@
 package config
 
 import (
+	"net"
+	"os"
 	"time"
 
+	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prebid/prebid-server/pbsmetrics"
 	"github.com/prebid/prebid-server/pbsmetrics/prometheus"
 	"github.com/rcrowley/go-metrics"
-	"github.com/vrischmann/go-metrics-influxdb"
 )
 
 // NewMetricsEngine reads the configuration and returns the appropriate metrics engine
@@ -20,20 +22,19 @@ func NewMetricsEngine(cfg *config.Configuration, adapterList []openrtb_ext.Bidde
 	engineList := make(MultiMetricsEngine, 0, 2)
 	returnEngine := DetailedMetricsEngine{}
 
-	if cfg.Metrics.Influxdb.Host != "" {
-		// Currently use go-metrics as the metrics piece for influx
-		returnEngine.GoMetrics = pbsmetrics.NewMetrics(metrics.NewPrefixedRegistry("prebidserver."), adapterList)
+	if cfg.Metrics.Graphite.Host != "" {
+		returnEngine.GoMetrics = pbsmetrics.NewMetrics(metrics.NewRegistry(), adapterList)
 		engineList = append(engineList, returnEngine.GoMetrics)
-		// Set up the Influx logger
-		go influxdb.InfluxDB(
-			returnEngine.GoMetrics.MetricsRegistry, // metrics registry
-			time.Second*10,                         // interval
-			cfg.Metrics.Influxdb.Host,              // the InfluxDB url
-			cfg.Metrics.Influxdb.Database,          // your InfluxDB database
-			cfg.Metrics.Influxdb.Username,          // your InfluxDB user
-			cfg.Metrics.Influxdb.Password,          // your InfluxDB password
+		// Set up the Graphite logger
+		addr, _ := net.ResolveTCPAddr("tcp", cfg.Metrics.Graphite.Host)
+		hostname, _ := os.Hostname()
+		go graphite.Graphite(
+			returnEngine.GoMetrics.MetricsRegistry,
+			time.Duration(cfg.Metrics.Graphite.IntervalSec)*time.Second,
+			"servers."+hostname+".prebid-server",
+			addr,
 		)
-		// Influx is not added to the engine list as goMetrics takes care of it already.
+		// Graphite is not added to the engine list as goMetrics takes care of it already.
 	}
 	if cfg.Metrics.Prometheus.Port != 0 {
 		// Set up the Prometheus metrics.

--- a/pbsmetrics/config/metrics_test.go
+++ b/pbsmetrics/config/metrics_test.go
@@ -38,7 +38,7 @@ func TestMultiMetricsEngine(t *testing.T) {
 	cfg := mainConfig.Configuration{}
 	cfg.Metrics.Influxdb.Host = "localhost"
 	cfg.Metrics.Graphite.Host = "localhost:2003"
-	cfg.Metrics.Graphite.Prefix = "test."
+	cfg.Metrics.Graphite.Prefix = "test"
 	adapterList := openrtb_ext.BidderList()
 	goEngine := pbsmetrics.NewMetrics(metrics.NewPrefixedRegistry("prebidserver."), adapterList)
 	engineList := make(MultiMetricsEngine, 2)

--- a/pbsmetrics/config/metrics_test.go
+++ b/pbsmetrics/config/metrics_test.go
@@ -23,6 +23,7 @@ func TestDummyMetricsEngine(t *testing.T) {
 
 func TestGoMetricsEngine(t *testing.T) {
 	cfg := mainConfig.Configuration{}
+	cfg.Metrics.Influxdb.Host = "localhost"
 	cfg.Metrics.Graphite.Host = "localhost:2003"
 	adapterList := make([]openrtb_ext.BidderName, 0, 2)
 	testEngine := NewMetricsEngine(&cfg, adapterList)
@@ -35,7 +36,9 @@ func TestGoMetricsEngine(t *testing.T) {
 // Test the multiengine
 func TestMultiMetricsEngine(t *testing.T) {
 	cfg := mainConfig.Configuration{}
+	cfg.Metrics.Influxdb.Host = "localhost"
 	cfg.Metrics.Graphite.Host = "localhost:2003"
+	cfg.Metrics.Graphite.Prefix = "test."
 	adapterList := openrtb_ext.BidderList()
 	goEngine := pbsmetrics.NewMetrics(metrics.NewPrefixedRegistry("prebidserver."), adapterList)
 	engineList := make(MultiMetricsEngine, 2)

--- a/pbsmetrics/config/metrics_test.go
+++ b/pbsmetrics/config/metrics_test.go
@@ -23,7 +23,7 @@ func TestDummyMetricsEngine(t *testing.T) {
 
 func TestGoMetricsEngine(t *testing.T) {
 	cfg := mainConfig.Configuration{}
-	cfg.Metrics.Influxdb.Host = "localhost"
+	cfg.Metrics.Graphite.Host = "localhost:2003"
 	adapterList := make([]openrtb_ext.BidderName, 0, 2)
 	testEngine := NewMetricsEngine(&cfg, adapterList)
 	_, ok := testEngine.MetricsEngine.(*pbsmetrics.Metrics)
@@ -35,7 +35,7 @@ func TestGoMetricsEngine(t *testing.T) {
 // Test the multiengine
 func TestMultiMetricsEngine(t *testing.T) {
 	cfg := mainConfig.Configuration{}
-	cfg.Metrics.Influxdb.Host = "localhost"
+	cfg.Metrics.Graphite.Host = "localhost:2003"
 	adapterList := openrtb_ext.BidderList()
 	goEngine := pbsmetrics.NewMetrics(metrics.NewPrefixedRegistry("prebidserver."), adapterList)
 	engineList := make(MultiMetricsEngine, 2)


### PR DESCRIPTION
If no prefix for graphite is configured, metrics will start with a dot. "prebidserver" always prefixes the metrics (which is the hardcoded prefix influxdb originally uses)